### PR TITLE
Fixed issue when clicking new chat while answer was steaming.

### DIFF
--- a/saas-frontend/src/pages/taChatbot/chatpage.js
+++ b/saas-frontend/src/pages/taChatbot/chatpage.js
@@ -118,6 +118,7 @@ const ChatPage = () => {
         try {
             setCurrentSessionKey('');
             setMessages([]);
+            abortController.abort();
 
             const sessionResponse = await fetch(`${apiUrl}/chat/createSession`, {
                 method: 'POST',


### PR DESCRIPTION
Fixes #40 

Now when new chat is clicked the UI stops streaming the LLM response. 

Worth noting, the backend will still be streaming and the entire answer is be appended when the LLM finishes responding in the backend. This behavior will require refactoring the API in able to stop the streaming from the LLM.